### PR TITLE
fixed JS uncaught TypeError

### DIFF
--- a/js/turiknox/addressautocomplete.js
+++ b/js/turiknox/addressautocomplete.js
@@ -72,7 +72,7 @@ var AddressAutocomplete = Class.create({
                 event.preventDefault();
                 this.element.blur();
             }
-        });
+        }.bind(this));
     },
 
     /**


### PR DESCRIPTION
`this` refers to the pressed element in this case and not to the class. Hence, `this.element` is undefined and leads to the following error:

    Uncaught TypeError: Cannot read property 'blur' of undefined